### PR TITLE
Logging of all public channels by default. 

### DIFF
--- a/src/channels.tin
+++ b/src/channels.tin
@@ -17,26 +17,54 @@
 #ACTION {^You cre-tell:%1} {#LINE {LOG} {$chat_file}};
 
 
-#ACTION {^(Playerkillers) %1 wisps{:|} %2} {
-    #if {"$talker_log_toggle" == "1"} {
-        #LINE {LOG} {$chat_file}
-    };
+#VAR {talker_channels} {
+    {adventurers}{^(Adventurers)}
+    {amPalaceGuard}{^(Ankh-MorporkPalaceGuard)}
+    {apex}{^(Apex)}
+    {assassins}{^(Assassins)}
+    {atuin}{^(A'Tuin)}
+    {conlegiumSicariorum}{^(ConlegiumSicariorum)}
+    {dead}{^(Dead)}
+    {djelianGuard}{^(DjelianGuard)}
+    {duchessSaturdaysMusketeers}{^(DuchessSaturday'sMusketeers)}
+    {fish}{^(Fish)}
+    {gapp}{^(Gapp)}
+    {gufnork}{^(Gufnork)}
+    {hashishim}{^(Hashishim)}
+    {hat}{^(Hat)}
+    {hublandishBarbarians}{^(HublandishBarbarians)}
+    {hunters}{^(Hunters)}
+    {igame}{^(Igame)}
+    {imperialGuard}{^(ImperialGuard)}
+    {intermud}{^(Intermud)}
+    {klatchianForeignLegion}{^(KlatchianForeignLegion)}
+    {lancreHighlandRegiment}{^(LancreHighlandRegiment)}
+    {manoRossa}{^(ManoRossa)}
+    {ninjas}{^(Ninjas)}
+    {one}{^(One)}
+    {pishe}{^(Pishe)}
+    {playerkillers}{^(Playerkillers)}
+    {playtesters}{^(Playtesters)}
+    {priests}{^(Priests)}
+    {quiz}{^(Quiz)}
+    {samurai}{^(Samurai)}
+    {sandelfon}{^(Sandelfon)}
+    {sek}{^(Sek)}
+    {thieves}{^(Thieves)}
+    {two}{^(Two)}
+    {warriors}{^(Warriors)}
+    {weaponMastersCourt}{^(WeaponMasters'Court)}
+    {witches}{^(Witches)}
+    {wizards}{^(Wizards)}
 };
-#ACTION {^(Thieves) %1 wisps{:|} %2} {
-    #if {"$talker_log_toggle" == "1"} {
-        #LINE {LOG} {$chat_file}
-    };
-};
-#ACTION {^(Wizards) %1 wisps{:|} %2} {
-    #if {"$talker_log_toggle" == "1"} {
-        #LINE {LOG} {$chat_file}
-    };
-};
-#ACTION {^(Igame) %1 wisps{:|} %2} {
-    #if {"$talker_log_toggle" == "1"} {
-        #LINE {LOG} {$chat_file}
-    };
-};
+
+#FOREACH {$talker_channels[%*]} {talker_channel} {
+  #ACTION {$talker_channel %1 wisps{:|} %2} {
+      #if {"$talker_log_toggle" == "1"} {
+          #LINE {LOG} {$chat_file}
+      };
+  };
+}
 
 #ALIAS {talker log %1} {
     #if {%1 == "on"} {


### PR DESCRIPTION
- The change is a small refactoring code wise to go over a list of talker channels and add the actions instead of having copy pasted code. 
- In addition I added all public channels I am aware of. 
- Tested with the additional channels not already in before and which I have access to (ConlegiumSicariorum, Assassins, Pishe, Priests, Witches, One). I presume the solution to work across the board as I don't have an army of alts. =)

From a performance point of view I think that the additional matchings are negligible. 

Thanks for considering. 